### PR TITLE
[05] ヘッダー・フッター修正

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -26,40 +26,15 @@
     </v-navigation-drawer>
     <v-app-bar :clipped-left="clipped" fixed app>
       <v-app-bar-nav-icon @click.stop="drawer = !drawer" />
-      <v-btn icon @click.stop="miniVariant = !miniVariant">
-        <v-icon>mdi-{{ `chevron-${miniVariant ? 'right' : 'left'}` }}</v-icon>
-      </v-btn>
-      <v-btn icon @click.stop="clipped = !clipped">
-        <v-icon>mdi-application</v-icon>
-      </v-btn>
-      <v-btn icon @click.stop="fixed = !fixed">
-        <v-icon>mdi-minus</v-icon>
-      </v-btn>
       <v-toolbar-title v-text="title" />
-      <v-spacer />
-      <v-btn icon @click.stop="rightDrawer = !rightDrawer">
-        <v-icon>mdi-menu</v-icon>
-      </v-btn>
     </v-app-bar>
     <v-content>
       <v-container>
         <nuxt />
       </v-container>
     </v-content>
-    <v-navigation-drawer v-model="rightDrawer" :right="right" temporary fixed>
-      <v-list>
-        <v-list-item @click.native="right = !right">
-          <v-list-item-action>
-            <v-icon light>
-              mdi-repeat
-            </v-icon>
-          </v-list-item-action>
-          <v-list-item-title>Switch drawer (click me)</v-list-item-title>
-        </v-list-item>
-      </v-list>
-    </v-navigation-drawer>
     <v-footer :fixed="fixed" app>
-      <span>&copy; {{ new Date().getFullYear() }}</span>
+      <span>&copy; {{ new Date().getFullYear() }} FGO damage calculation</span>
     </v-footer>
   </v-app>
 </template>
@@ -86,7 +61,7 @@ export default {
       miniVariant: false,
       right: true,
       rightDrawer: false,
-      title: 'Vuetify.js'
+      title: 'FGO ダメージ計算機'
     }
   }
 }


### PR DESCRIPTION
(issues --> #5 )

◯プロジェクト作成時にできた`layouts/default.vue`のヘッダーとフッターの部分を修正

・実装前
<img width="1440" alt="スクリーンショット 2020-05-12 23 07 29" src="https://user-images.githubusercontent.com/55835461/81705690-47500880-94aa-11ea-9cfb-bf960bcd9588.png">

・実装後
<img width="1440" alt="スクリーンショット 2020-05-12 23 31 51" src="https://user-images.githubusercontent.com/55835461/81705721-4f0fad00-94aa-11ea-96f1-40e115618c46.png">

◯疑問点
`layouts/default.vue`から
Headerコンポーネント、Footerコンポーネントを作成しファイルを独立させるべきかどうか